### PR TITLE
fix: ParseDatetimeRFC3339 utilises base time.RFC3339

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -1,5 +1,5 @@
 mode: atomic
-github.com/observerly/nocturnal/internal/utils/datetime.go:7.56,9.2 1 1
+github.com/observerly/nocturnal/internal/utils/datetime.go:5.56,7.2 1 2
 github.com/observerly/nocturnal/internal/router/setup.go:11.36,13.13 2 1
 github.com/observerly/nocturnal/internal/router/setup.go:16.2,16.14 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:13.13,15.3 1 1
@@ -12,5 +12,5 @@ github.com/observerly/nocturnal/internal/router/setup.go:24.23,26.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:31.41,38.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:41.40,50.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:53.33,55.3 1 1
-github.com/observerly/nocturnal/pkg/moon/moon.go:15.30,62.2 14 1
 github.com/observerly/nocturnal/pkg/sun/sun.go:15.29,49.2 11 1
+github.com/observerly/nocturnal/pkg/moon/moon.go:15.30,62.2 14 1

--- a/internal/utils/datetime.go
+++ b/internal/utils/datetime.go
@@ -2,8 +2,6 @@ package utils
 
 import "time"
 
-const RFC3339 = "2006-01-02T15:04:05.000Z"
-
 func ParseDatetimeRFC3339(d string) (time.Time, error) {
-	return time.Parse(RFC3339, d)
+	return time.Parse(time.RFC3339, d)
 }

--- a/internal/utils/datetime_test.go
+++ b/internal/utils/datetime_test.go
@@ -20,3 +20,17 @@ func TestParseDatetimeRFC3339(t *testing.T) {
 	assert.Equal(t, datetime.Minute(), 4)
 	assert.Equal(t, datetime.Second(), 5)
 }
+
+func TestParseDatetimeRFC3339Alt(t *testing.T) {
+	d := "2021-05-14T00:00:00.000Z"
+
+	datetime, _ := ParseDatetimeRFC3339(d)
+
+	// Assert we get the correctly parse datetime:
+	assert.Equal(t, datetime.Year(), 2021)
+	assert.Equal(t, datetime.Month(), time.Month(5))
+	assert.Equal(t, datetime.Day(), 14)
+	assert.Equal(t, datetime.Hour(), 0)
+	assert.Equal(t, datetime.Minute(), 0)
+	assert.Equal(t, datetime.Second(), 0)
+}


### PR DESCRIPTION
fix: ParseDatetimeRFC3339 utilises base time.RFC3339. 

Includes improved test coverage for expected output.