### PR TITLE
feat: Added transit { rise, set } times to GetMoon() *gin.Context.

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -16,6 +16,12 @@ github.com/observerly/nocturnal/internal/router/setup.go:36.40,43.4 1 0
 github.com/observerly/nocturnal/internal/router/setup.go:47.41,54.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:57.40,66.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:69.33,71.3 1 1
-github.com/observerly/nocturnal/pkg/moon/moon.go:15.30,62.2 14 1
-github.com/observerly/nocturnal/pkg/twilight/twilight.go:14.34,75.2 14 1
 github.com/observerly/nocturnal/pkg/sun/sun.go:15.29,49.2 11 1
+github.com/observerly/nocturnal/pkg/twilight/twilight.go:14.34,75.2 14 1
+github.com/observerly/nocturnal/pkg/moon/moon.go:15.30,61.22 16 1
+github.com/observerly/nocturnal/pkg/moon/moon.go:67.2,67.21 1 1
+github.com/observerly/nocturnal/pkg/moon/moon.go:73.2,78.4 1 1
+github.com/observerly/nocturnal/pkg/moon/moon.go:61.22,63.3 1 0
+github.com/observerly/nocturnal/pkg/moon/moon.go:63.8,65.3 1 1
+github.com/observerly/nocturnal/pkg/moon/moon.go:67.21,69.3 1 0
+github.com/observerly/nocturnal/pkg/moon/moon.go:69.8,71.3 1 1

--- a/pkg/moon/moon.go
+++ b/pkg/moon/moon.go
@@ -33,6 +33,8 @@ func GetMoon(c *gin.Context) {
 
 	ph := dusk.GetLunarPhase(datetime, longitude, ec)
 
+	rs, _ := dusk.GetMoonriseMoonsetTimes(datetime, longitude, latitude)
+
 	observer := gin.H{
 		"datetime":  datetime,
 		"longitude": fmt.Sprintf("%f", longitude),
@@ -54,9 +56,24 @@ func GetMoon(c *gin.Context) {
 		"illumination": fmt.Sprintf("%f", ph.Illumination),
 	}
 
+	transit := gin.H{}
+
+	if rs.Rise.IsZero() {
+		transit["rise"] = nil
+	} else {
+		transit["rise"] = rs.Rise.Format(time.RFC3339)
+	}
+
+	if rs.Set.IsZero() {
+		transit["set"] = nil
+	} else {
+		transit["set"] = rs.Set.Format(time.RFC3339)
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"observer": observer,
 		"position": position,
 		"phase":    phase,
+		"transit":  transit,
 	})
 }

--- a/pkg/moon/moon_test.go
+++ b/pkg/moon/moon_test.go
@@ -154,3 +154,27 @@ func TestGetMoonRoutePosition(t *testing.T) {
 	assert.Equal(t, ra, position["ra"])
 	assert.Equal(t, dec, position["dec"])
 }
+
+func TestGetMoonRouteTransit(t *testing.T) {
+	// Build our expected transit section of body
+	transit := gin.H{
+		"rise": "2021-05-14T07:57:00-10:00",
+		"set":  "2021-05-14T21:42:00-10:00",
+	}
+
+	// Convert the JSON response:
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+
+	// Grab the transit & whether or not it exists
+	rise, exists := response["transit"]["rise"]
+	assert.True(t, exists)
+
+	// Grab the transit & whether or not it exists
+	set, exists := response["transit"]["set"]
+	assert.True(t, exists)
+
+	// Assert on the correctness of the response:
+	assert.Nil(t, err)
+	assert.Equal(t, rise, transit["rise"])
+	assert.Equal(t, set, transit["set"])
+}


### PR DESCRIPTION
feat: Added transit { rise, set } times to GetMoon() *gin.Context. gin.H{} return. 

Includes associated updates to test suite for expected output of transit times in RFC3339 format.