### PR TITLE
feat: Added transit { rise, set } times to GetSun() *gin.Context.

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -16,7 +16,6 @@ github.com/observerly/nocturnal/internal/router/setup.go:38.40,45.4 1 0
 github.com/observerly/nocturnal/internal/router/setup.go:58.41,65.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:68.40,77.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:80.33,82.3 1 1
-github.com/observerly/nocturnal/pkg/twilight/twilight.go:14.34,75.2 14 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:15.30,61.22 16 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:67.2,67.21 1 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:73.2,78.4 1 1
@@ -24,4 +23,5 @@ github.com/observerly/nocturnal/pkg/moon/moon.go:61.22,63.3 1 0
 github.com/observerly/nocturnal/pkg/moon/moon.go:63.8,65.3 1 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:67.21,69.3 1 0
 github.com/observerly/nocturnal/pkg/moon/moon.go:69.8,71.3 1 1
+github.com/observerly/nocturnal/pkg/twilight/twilight.go:14.34,75.2 14 1
 github.com/observerly/nocturnal/pkg/sun/sun.go:15.29,57.2 13 1

--- a/pkg/sun/sun.go
+++ b/pkg/sun/sun.go
@@ -29,6 +29,8 @@ func GetSun(c *gin.Context) {
 
 	hz := dusk.ConvertEquatorialCoordinateToHorizontal(datetime, longitude, latitude, eq)
 
+	rs, _ := dusk.GetSunriseSunsetTimes(datetime, 0, longitude, latitude, 0)
+
 	observer := gin.H{
 		"datetime":  datetime,
 		"longitude": fmt.Sprintf("%f", longitude),
@@ -42,8 +44,14 @@ func GetSun(c *gin.Context) {
 		"dec": fmt.Sprintf("%f", eq.Declination),
 	}
 
+	transit := gin.H{
+		"rise": rs.Rise.Format(time.RFC3339),
+		"set":  rs.Set.Format(time.RFC3339),
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"observer": observer,
 		"position": position,
+		"transit":  transit,
 	})
 }

--- a/pkg/sun/sun_test.go
+++ b/pkg/sun/sun_test.go
@@ -112,3 +112,27 @@ func TestGetSunRoutePosition(t *testing.T) {
 	assert.Equal(t, ra, position["ra"])
 	assert.Equal(t, dec, position["dec"])
 }
+
+func TestGetSunRouteTransit(t *testing.T) {
+	// Build our expected transit section of body
+	transit := gin.H{
+		"rise": "2021-05-14T05:49:45-10:00",
+		"set":  "2021-05-14T18:46:50-10:00",
+	}
+
+	// Convert the JSON response:
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+
+	// Grab the transit & whether or not it exists
+	rise, exists := response["transit"]["rise"]
+	assert.True(t, exists)
+
+	// Grab the transit & whether or not it exists
+	set, exists := response["transit"]["set"]
+	assert.True(t, exists)
+
+	// Assert on the correctness of the response:
+	assert.Nil(t, err)
+	assert.Equal(t, rise, transit["rise"])
+	assert.Equal(t, set, transit["set"])
+}


### PR DESCRIPTION
feat: Added transit { rise, set } times to GetSun() *gin.Context. gin.H{} return. 

Includes associated updates to test suite for expected output of transit times in RFC3339 format.