### PR TITLE
fix: Ensure GetTwilight() *gin.Context returns correct JSON types.

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -19,8 +19,7 @@ github.com/observerly/nocturnal/internal/router/setup.go:38.40,45.4 1 0
 github.com/observerly/nocturnal/internal/router/setup.go:58.41,65.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:68.40,77.3 1 1
 github.com/observerly/nocturnal/internal/router/setup.go:80.33,82.3 1 1
-github.com/observerly/nocturnal/pkg/sun/sun.go:15.29,57.2 13 1
-github.com/observerly/nocturnal/pkg/twilight/twilight.go:14.34,75.2 14 1
+github.com/observerly/nocturnal/pkg/twilight/twilight.go:13.34,74.2 14 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:15.30,61.22 16 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:67.2,67.21 1 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:73.2,78.4 1 1
@@ -28,4 +27,5 @@ github.com/observerly/nocturnal/pkg/moon/moon.go:61.22,63.3 1 0
 github.com/observerly/nocturnal/pkg/moon/moon.go:63.8,65.3 1 1
 github.com/observerly/nocturnal/pkg/moon/moon.go:67.21,69.3 1 0
 github.com/observerly/nocturnal/pkg/moon/moon.go:69.8,71.3 1 1
+github.com/observerly/nocturnal/pkg/sun/sun.go:15.29,57.2 13 1
 github.com/observerly/nocturnal/pkg/transit/transit.go:15.33,93.2 25 3

--- a/pkg/twilight/twilight.go
+++ b/pkg/twilight/twilight.go
@@ -1,7 +1,6 @@
 package twilight
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -26,8 +25,8 @@ func GetTwilight(c *gin.Context) {
 
 	observer := gin.H{
 		"datetime":  datetime,
-		"longitude": fmt.Sprintf("%f", longitude),
-		"latitude":  fmt.Sprintf("%f", latitude),
+		"longitude": longitude,
+		"latitude":  latitude,
 	}
 
 	// Civil Twilight:

--- a/pkg/twilight/twilight_test.go
+++ b/pkg/twilight/twilight_test.go
@@ -51,8 +51,8 @@ func TestGetTwilightRouteObserver(t *testing.T) {
 	// Build our expected observer section of body
 	observer := gin.H{
 		"datetime":  "2021-05-14T00:00:00Z",
-		"latitude":  "19.798484",
-		"longitude": "-155.468094",
+		"latitude":  19.798484,
+		"longitude": -155.468094,
 	}
 
 	// Convert the JSON response:


### PR DESCRIPTION
fix: Ensure GetTwilight() *gin.Context returns correct JSON types. 

Includes updated associated test suite for module export definition accuracy and expected output.